### PR TITLE
Catchall Handler to Send Help Text

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,15 @@ controller.hears('log', 'direct_message', function(bot, message){
     });
 });
 
+controller.on('direct_message', function(bot, message){
+    if(!message.text.match('^log .+')){
+        writeHelpText(message);
+    }
+});
+
+function writeHelpText(message){
+    bot.api.message.reply(message, "Sorry, I didn't understand that. Here are the commands I support:\n`log [text to log]`");
+}
 
 /**
  * AN example of what could be:

--- a/index.js
+++ b/index.js
@@ -104,12 +104,12 @@ controller.hears('log', 'direct_message', function(bot, message){
 
 controller.on('direct_message', function(bot, message){
     if(!message.text.match('^log .+')){
-        writeHelpText(message);
+        writeHelpText(bot, message);
     }
 });
 
-function writeHelpText(message){
-    bot.api.message.reply(message, "Sorry, I didn't understand that. Here are the commands I support:\n`log [text to log]`");
+function writeHelpText(bot, message){
+    bot.reply(message, "Sorry, I didn't understand that. Here are the commands I support:\n`log [text to log]`");
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -102,29 +102,7 @@ controller.hears('log', 'direct_message', function(bot, message){
     });
 });
 
+// LAST handler. Catchall to display supported commands.
 controller.on('direct_message', function(bot, message){
-    if(!message.text.match('^log .+')){
-        writeHelpText(bot, message);
-    }
-});
-
-function writeHelpText(bot, message){
     bot.reply(message, "Sorry, I didn't understand that. Here are the commands I support:\n`log [text to log]`");
-}
-
-/**
- * AN example of what could be:
- * Any un-handled direct mention gets a reaction and a pat response!
- */
-//controller.on('direct_message,mention,direct_mention', function (bot, message) {
-//    bot.api.reactions.add({
-//        timestamp: message.ts,
-//        channel: message.channel,
-//        name: 'robot_face',
-//    }, function (err) {
-//        if (err) {
-//            console.log(err)
-//        }
-//        bot.reply(message, 'I heard you loud and clear boss.');
-//    });
-//});
+});


### PR DESCRIPTION
If the bot gets a DM that isn't handled by another handler, display the supported commands.